### PR TITLE
Add additional order metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@
 ### Adds the following sensors
 * Current orders needing to be shipped out
 * Current orders needing to be shipped out <strong>today</strong>
+* Orders awaiting payment
+* Fulfilled orders
+* Cancelled orders
+* Return requests
+* Cancellation requests
+* Active listings
+* Listing impressions
+* Listing page views
+* Listing click-through rate
 * Available Funds
 * Total Funds
 * Funds on Hold

--- a/custom_components/eBay/const.py
+++ b/custom_components/eBay/const.py
@@ -8,10 +8,22 @@ OAUTH2_TOKEN = "https://api.ebay.com/identity/v1/oauth2/token"
 SCOPES = (
     "https://api.ebay.com/oauth/api_scope/sell.fulfillment.readonly",
     "https://api.ebay.com/oauth/api_scope/sell.finances",
+    "https://api.ebay.com/oauth/api_scope/sell.analytics.readonly",
+    "https://api.ebay.com/oauth/api_scope/sell.inventory.readonly",
+    "https://api.ebay.com/oauth/api_scope/sell.postorder.readonly",
 )
 UNFULFILLED_ORDERS_URL = "https://api.ebay.com/sell/fulfillment/v1/order?filter=orderfulfillmentstatus:%7BNOT_STARTED%7CIN_PROGRESS%7D"
+FULFILLED_ORDERS_URL = "https://api.ebay.com/sell/fulfillment/v1/order?filter=orderfulfillmentstatus:%7BFULFILLED%7D"
+CANCELLED_ORDERS_URL = "https://api.ebay.com/sell/fulfillment/v1/order?filter=orderfulfillmentstatus:%7BCANCELLED%7D"
 SELLER_FUNDS_SUMMARY_URL = "https://apiz.ebay.com/sell/finances/v1/seller_funds_summary"
 TRANSACTION_SUMMARY_URL = "https://apiz.ebay.com/sell/finances/v1/transaction_summary"
+RETURN_REQUESTS_URL = "https://api.ebay.com/post-order/v2/return/search"
+CANCELLATION_REQUESTS_URL = "https://api.ebay.com/post-order/v2/cancellation/search"
+ACTIVE_LISTINGS_URL = "https://api.ebay.com/sell/inventory/v1/inventory_item?status=ACTIVE&limit=1"
+TRAFFIC_REPORT_URL = (
+    "https://api.ebay.com/sell/analytics/v1/traffic_report?dimension=LISTING"
+    "&metric=LISTING_IMPRESSION,LISTING_VIEWS"
+)
 
 
 EBAY_QUERIES_SENSOR: tuple[SensorEntityDescription, ...] = (
@@ -84,5 +96,51 @@ EBAY_QUERIES_SENSOR: tuple[SensorEntityDescription, ...] = (
         name="eBay Refunds This Month",
         icon="mdi:cash-refund",
         native_unit_of_measurement="USD",
+    ),
+    SensorEntityDescription(
+        key="ebay_orders_awaiting_payment",
+        name="eBay Orders Awaiting Payment",
+        icon="mdi:cash-clock",
+    ),
+    SensorEntityDescription(
+        key="ebay_fulfilled_orders",
+        name="eBay Fulfilled Orders",
+        icon="mdi:package-variant-closed-check",
+    ),
+    SensorEntityDescription(
+        key="ebay_cancelled_orders",
+        name="eBay Cancelled Orders",
+        icon="mdi:package-variant-closed-remove",
+    ),
+    SensorEntityDescription(
+        key="ebay_return_requests",
+        name="eBay Return Requests",
+        icon="mdi:clipboard-list",
+    ),
+    SensorEntityDescription(
+        key="ebay_cancellation_requests",
+        name="eBay Cancellation Requests",
+        icon="mdi:cancel",
+    ),
+    SensorEntityDescription(
+        key="ebay_active_listings",
+        name="eBay Active Listings",
+        icon="mdi:storefront-outline",
+    ),
+    SensorEntityDescription(
+        key="ebay_listing_impressions",
+        name="eBay Listing Impressions",
+        icon="mdi:eye-outline",
+    ),
+    SensorEntityDescription(
+        key="ebay_listing_page_views",
+        name="eBay Listing Page Views",
+        icon="mdi:eye",
+    ),
+    SensorEntityDescription(
+        key="ebay_click_through_rate",
+        name="eBay Click Through Rate",
+        icon="mdi:cursor-pointer",
+        native_unit_of_measurement="%",
     ),
 )


### PR DESCRIPTION
## Summary
- track orders awaiting payment using standard Fulfillment API
- expose total fulfilled and cancelled order counts
- track return/cancellation requests and listing traffic metrics

## Testing
- `python -m py_compile custom_components/eBay/api.py custom_components/eBay/const.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb4914889c832d91fc977a097b197a